### PR TITLE
📝 Feat: Drawer 추가(#48)

### DIFF
--- a/lib/provider/util_provider.dart
+++ b/lib/provider/util_provider.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+class UtilProvider with ChangeNotifier {
+  bool _canSeeDetail = false;
+  Color _themeColor = Colors.lightGreen;
+  int _drawerIndex = 0;
+  late List<DrawerTile> _drawerList;
+
+  UtilProvider() {
+    _drawerList = [
+      DrawerTile(
+        title: "Main Page",
+        icon: Icon(Icons.home_max_outlined),
+        pageRoute: "/",
+      ),
+      DrawerTile(
+        title: "My Page",
+        icon: Icon(Icons.settings),
+        pageRoute: "/route",
+      ),
+      DrawerTile(
+        title: "Go Plogging",
+        icon: Icon(Icons.run_circle_outlined),
+        pageRoute: "/google-map",
+      ),
+      DrawerTile(
+        title: "Update Trashcan",
+        icon: Icon(Icons.restore_from_trash_outlined),
+        pageRoute: "/trash",
+      ),
+    ];
+  }
+
+  bool get canSeeDetail => _canSeeDetail;
+  Color get themeColor => _themeColor;
+  List<DrawerTile> get drawerList => _drawerList;
+  int get drawerIndex => _drawerIndex;
+
+  void toggleDetailButton() {
+    _canSeeDetail = !_canSeeDetail;
+    notifyListeners();
+  }
+
+  void changeSelectIndex(int index) {
+    _drawerIndex = index;
+    notifyListeners();
+  }
+}
+
+class DrawerTile {
+  final String _title;
+  final Icon _icon;
+  final String _pageRoute;
+
+  DrawerTile(
+      {required String title, required Icon icon, required String pageRoute})
+      : _title = title,
+        _icon = icon,
+        _pageRoute = pageRoute;
+
+  String get title => _title;
+  Icon get icon => _icon;
+  String get pageRoute => _pageRoute;
+}

--- a/lib/ui/component/plug_in_drawer.dart
+++ b/lib/ui/component/plug_in_drawer.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:plug_in/provider/member_provider.dart';
+import 'package:provider/provider.dart';
+
+import '../../provider/util_provider.dart';
+
+class PlugInDrawer extends StatelessWidget {
+  const PlugInDrawer({Key? key}) : super(key: key);
+
+  final BorderRadius _roundBorderRadius = const BorderRadius.only(
+    bottomLeft: Radius.circular(50.0),
+    bottomRight: Radius.circular(50.0),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<MemberProvider>(
+      builder: (context, memberProvider, child) => Consumer<UtilProvider>(
+        builder: (context, utilProvider, child) => Drawer(
+          child: Column(
+            mainAxisSize: MainAxisSize.max,
+            children: [
+              Expanded(
+                child: ListView(
+                  padding: EdgeInsets.zero,
+                  children: [
+                    UserAccountsDrawerHeader(
+                      margin: EdgeInsets.zero,
+                      currentAccountPicture: CircleAvatar(
+                        child: Text(
+                          "🥰",
+                          style: TextStyle(fontSize: 45.0),
+                        ),
+                        backgroundColor: Colors.white,
+                      ),
+                      accountName: Text(memberProvider.member.name),
+                      accountEmail: Text(memberProvider.member.email),
+                      decoration: BoxDecoration(
+                        color: utilProvider.themeColor,
+                      ),
+                      onDetailsPressed: () {
+                        utilProvider.toggleDetailButton();
+                      },
+                    ),
+                    utilProvider.canSeeDetail
+                        ? Container(
+                            height: 40.0,
+                            child: Center(
+                              child: Text(
+                                "백도훈의 프로필입니다.",
+                                style: TextStyle(color: Colors.white),
+                              ),
+                            ),
+                            decoration: BoxDecoration(
+                              color: utilProvider.themeColor,
+                              borderRadius: _roundBorderRadius,
+                            ),
+                          )
+                        : const SizedBox(
+                            height: 0.0,
+                          ),
+                    ListView.builder(
+                      padding: EdgeInsets.zero,
+                      shrinkWrap: true,
+                      itemCount: utilProvider.drawerList.length,
+                      itemBuilder: (context, index) => ListTile(
+                        selected: ModalRoute.of(context)?.settings.name ==
+                            utilProvider.drawerList[index].pageRoute,
+                        selectedColor: Colors.lightGreen,
+                        leading: utilProvider.drawerList[index].icon,
+                        title: Text(utilProvider.drawerList[index].title),
+                        onTap: () {
+                          utilProvider.changeSelectIndex(index);
+                          Navigator.pushNamed(context,
+                              utilProvider.drawerList[index].pageRoute);
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SafeArea(
+                child: Row(
+                  children: [
+                    Flexible(
+                      child: ListTile(),
+                    ),
+                    Flexible(
+                      child: ListTile(
+                        leading: Icon(Icons.logout_outlined),
+                        title: Text("Logout"),
+                      ),
+                    )
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 개요
- #48
- #50 
- Drawer 추가했습니다. 

## 작업사항
- 간단 프로필 확인 가능
- 페이지 라우팅 가능

![image](https://user-images.githubusercontent.com/65100540/155643049-5e04c0bb-9485-46a1-a904-17bce994ea1d.png)


## 사용 방법(Optional)
- Scaffold에 endDrawer 속성에 사용하면 됩니다!
```dart
Scaffold(
      extendBodyBehindAppBar: true, // 앱바 위쪽 공간에도 drawer가 올라갈건지
      appBar: PlugInAppBar(title: "Plug In"),
      endDrawer: PlugInDrawer(),
      body: SafeArea(...),
    );
